### PR TITLE
fix: resolve failed initialization due to deprecated ABC import

### DIFF
--- a/vot/analysis/_processor.py
+++ b/vot/analysis/_processor.py
@@ -1,7 +1,12 @@
 
 import logging
+import sys
 import threading
-from collections import Iterable, OrderedDict, namedtuple
+from collections import OrderedDict, namedtuple
+if sys.version_info >= (3, 3):
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
 from functools import partial
 from typing import List, Union, Mapping, Tuple, Any
 from concurrent.futures import Executor, Future, ThreadPoolExecutor

--- a/vot/document/__init__.py
+++ b/vot/document/__init__.py
@@ -10,6 +10,8 @@ import logging
 import tempfile
 import datetime
 import collections
+import collections.abc
+import sys
 from asyncio import wait
 from asyncio.futures import wrap_future
 
@@ -344,7 +346,11 @@ class Generator(Attributee):
         raise NotImplementedError
 
     async def process(self, analyses, experiment, trackers, sequences):
-        if not isinstance(analyses, collections.Iterable):
+        if sys.version_info >= (3, 3):
+            _Iterable = collections.abc.Iterable
+        else:
+            _Iterable = collections.Iterable
+        if not isinstance(analyses, _Iterable):
             analyses = [analyses]
 
         futures = []


### PR DESCRIPTION
This PR fixed the ABC import issue for python versions >= 3.10. Specifically, I've updated the code to import `Iterable` from `collections.abc` instead of `collections` based on the version information. Since python 3.3, ABCs like `Iterable` were moved to `collections.abc`, and they were finally dropped in 3.10.

Additionally, I noticed that your other code was using `typing`. However, for maximum compatibility, I've still used `collections.abc` for this specific issue.
