### PR TITLE
fix to issue #91: Variable self._runtime referenced before initialization in vot/tracker/__init__.py

### DIFF
--- a/vot/tracker/__init__.py
+++ b/vot/tracker/__init__.py
@@ -826,7 +826,7 @@ class MultiObjectTrackerRuntime(TrackerRuntime):
         """
 
         super().__init__(runtime.tracker)
-        if self._runtime.multiobject:
+        if runtime.multiobject:
             self._runtime = runtime
         else:
             self._runtime = [runtime]


### PR DESCRIPTION
Looks like the member variable `self._runtime` is referenced before being initialized in [`vot/tracker/__init__.py` line 829](https://github.com/votchallenge/toolkit/blob/410c41f2cc35435f25083d6710bcfe478874d972/vot/tracker/__init__.py#L829
) resulting in the error:

```
Traceback (most recent call last):
  File "/usr/mvl2/itdfh/anaconda3/envs/vot/lib/python3.10/site-packages/vot/utilities/cli.py", line 412, in main
    do_evaluate(args)
  File "/usr/mvl2/itdfh/anaconda3/envs/vot/lib/python3.10/site-packages/vot/utilities/cli.py", line 200, in do_evaluate
    run_experiment(experiment, tracker, workspace.dataset, config.force, config.persist)
  File "/usr/mvl2/itdfh/anaconda3/envs/vot/lib/python3.10/site-packages/vot/experiment/__init__.py", line 201, in run_experiment
    experiment.execute(tracker, sequence, force=force, callback=progress)
  File "/usr/mvl2/itdfh/anaconda3/envs/vot/lib/python3.10/site-packages/vot/experiment/multirun.py", line 99, in execute
    with self._get_runtime(tracker, sequence, self._multiobject) as runtime:
  File "/usr/mvl2/itdfh/anaconda3/envs/vot/lib/python3.10/site-packages/vot/experiment/__init__.py", line 109, in _get_runtime
    runtime = MultiObjectTrackerRuntime(runtime)
  File "/usr/mvl2/itdfh/anaconda3/envs/vot/lib/python3.10/site-packages/vot/tracker/__init__.py", line 555, in __init__
    if self._runtime.multiobject:
AttributeError: 'MultiObjectTrackerRuntime' object has no attribute '_runtime'
```

Changing this [line 829](https://github.com/votchallenge/toolkit/blob/410c41f2cc35435f25083d6710bcfe478874d972/vot/tracker/__init__.py#L829
) from:
```
        if self._runtime.multiobject:
```
to:
```
        if runtime:
```

solves the issue.

Have there been any successful uses of a multi-object tracker using this toolkit? Can I see some examples?