### PR TITLE
Fixing np.int alias removed in numpy 1.24

### DIFF
--- a/vot/analysis/longterm.py
+++ b/vot/analysis/longterm.py
@@ -32,7 +32,7 @@ def determine_thresholds(scores: Iterable[float], resolution: int) -> List[float
 
     if len(scores) > resolution - 2:
         delta = math.floor(len(scores) / (resolution - 2))
-        idxs = np.round(np.linspace(delta, len(scores) - delta, num=resolution - 2)).astype(np.int)
+        idxs = np.round(np.linspace(delta, len(scores) - delta, num=resolution - 2)).astype(int)
         thresholds = [scores[idx] for idx in idxs]
     else:
         thresholds = scores


### PR DESCRIPTION
The `np.int` alias for `int` in numpy  has been [deprecated](https://numpy.org/devdocs/release/1.20.0-notes#using-the-aliases-of-builtin-types-like-np-int-is-deprecated) in numpy 1.20 and [removed](https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations) in numpy 1.24.

Following [documentation](https://numpy.org/devdocs/release/1.20.0-notes#using-the-aliases-of-builtin-types-like-np-int-is-deprecated), I've replaced `np.int` to `int`:

> you have the following alternatives:
> * `np.int_` or `int` (the default), but be aware that it depends on the computer and operating system.

Do I need to update as well the numpy version listed in the requirements.txt file?