### PR TITLE
Add Point region type and VOTSp2026 point tracking stack

### DIFF
--- a/vot/analysis/point.py
+++ b/vot/analysis/point.py
@@ -1,0 +1,188 @@
+"""This module contains the implementation of point tracking performance measures."""
+
+import numpy as np
+from typing import List, Tuple, Any
+
+from attributee import Include
+
+from vot.tracker import Tracker, Trajectory
+from vot.dataset import Sequence
+from vot.experiment import Experiment
+from vot.experiment.multirun import UnsupervisedExperiment
+from vot.region import RegionType
+from vot.analysis import SeparableAnalysis, SequenceAggregator, \
+    MissingResultsException, Measure, Sorting, is_special
+from vot.utilities.data import Grid
+
+THRESHOLDS = [1, 2, 4, 8, 16]
+
+def compute_point_accuracy(predicted: list, groundtruth: list, width: int, height: int) -> Tuple[float, ...]:
+    """Compute per-threshold accuracy and d_avg for a single point trajectory.
+
+    For each frame where both prediction and groundtruth are valid points,
+    the L2 distance is computed in a normalized coordinate space equivalent
+    to 256x256 pixels, making the thresholds resolution-independent.
+
+    Args:
+        predicted (list): Predicted trajectory as a list of regions.
+        groundtruth (list): Groundtruth trajectory as a list of regions.
+        width (int): Frame width in pixels.
+        height (int): Frame height in pixels.
+
+    Returns:
+        Tuple of (d_avg, d_1, d_2, d_4, d_8, d_16, n_evaluated) where each d_t
+        is the fraction of frames where normalized L2 error < t, and n_evaluated
+        is the number of frames included in the computation.
+    """
+    sx = (width - 1) / 255.0
+    sy = (height - 1) / 255.0
+
+    counts = np.zeros(len(THRESHOLDS), dtype=np.float64)
+    n = 0
+
+    for pred, gt in zip(predicted, groundtruth):
+        if pred.type != RegionType.POINT or gt.type != RegionType.POINT:
+            continue
+        dx = (pred.x - gt.x) / sx
+        dy = (pred.y - gt.y) / sy
+        dist = np.sqrt(dx * dx + dy * dy)
+        for i, thr in enumerate(THRESHOLDS):
+            if dist < thr:
+                counts[i] += 1
+        n += 1
+
+    if n == 0:
+        return (0.0,) * (len(THRESHOLDS) + 1) + (0,)
+
+    fractions = counts / n
+    d_avg = float(np.mean(fractions))
+    return (d_avg,) + tuple(float(f) for f in fractions) + (n,)
+
+
+class PointAccuracy(SeparableAnalysis):
+    """Per-sequence point tracking accuracy. Computes d_avg and per-threshold
+    accuracy scores for each tracker on each sequence."""
+
+    @property
+    def _title_default(self):
+        """Returns the default title of the analysis."""
+        return "Point accuracy"
+
+    def describe(self):
+        """Returns descriptions of the results produced by this analysis."""
+        return (
+            Measure("Average point accuracy", "d_avg", minimal=0, maximal=1, direction=Sorting.DESCENDING),
+            Measure("Point accuracy at 1px", "d_1", minimal=0, maximal=1, direction=Sorting.DESCENDING),
+            Measure("Point accuracy at 2px", "d_2", minimal=0, maximal=1, direction=Sorting.DESCENDING),
+            Measure("Point accuracy at 4px", "d_4", minimal=0, maximal=1, direction=Sorting.DESCENDING),
+            Measure("Point accuracy at 8px", "d_8", minimal=0, maximal=1, direction=Sorting.DESCENDING),
+            Measure("Point accuracy at 16px", "d_16", minimal=0, maximal=1, direction=Sorting.DESCENDING),
+            None,  # frame count, used for weighted aggregation
+        )
+
+    def compatible(self, experiment: Experiment):
+        """Only compatible with unsupervised experiments."""
+        return isinstance(experiment, UnsupervisedExperiment)
+
+    def subcompute(self, experiment: Experiment, tracker: Tracker, sequence: Sequence, dependencies: List[Grid]) -> Tuple[Any]:
+        """Compute point accuracy for a single tracker on a single sequence.
+
+        Args:
+            experiment (Experiment): The experiment.
+            tracker (Tracker): The tracker.
+            sequence (Sequence): The sequence.
+            dependencies (List[Grid]): Unused.
+
+        Returns:
+            Tuple of (d_avg, d_1, d_2, d_4, d_8, d_16, n_frames).
+        """
+        trajectories = experiment.gather(tracker, sequence)
+
+        if len(trajectories) == 0:
+            raise MissingResultsException()
+
+        width, height = sequence.size
+
+        d_avg_sum = np.zeros(len(THRESHOLDS) + 1, dtype=np.float64)
+        n_total = 0
+
+        for o in sequence.objects():
+            gt = [sequence.frame(i).object(o) for i in range(len(sequence))]
+            trajectories_o = experiment.gather(tracker, sequence, objects=[o])
+            if len(trajectories_o) == 0:
+                continue
+            pred = trajectories_o[0].regions()
+            result = compute_point_accuracy(pred, gt, width, height)
+            n = result[-1]
+            if n > 0:
+                for k in range(len(THRESHOLDS) + 1):
+                    d_avg_sum[k] += result[k] * n
+                n_total += n
+
+        if n_total == 0:
+            return (0.0,) * (len(THRESHOLDS) + 1) + (0,)
+
+        averaged = tuple(float(d_avg_sum[k] / n_total) for k in range(len(THRESHOLDS) + 1))
+        return averaged + (n_total,)
+
+
+class AveragePointAccuracy(SequenceAggregator):
+    """Dataset-level point tracking accuracy. Aggregates per-sequence results
+    from PointAccuracy into a single weighted average over all sequences."""
+
+    analysis = Include(PointAccuracy)
+
+    @property
+    def _title_default(self):
+        """Returns the default title of the analysis."""
+        return "Average point accuracy"
+
+    def dependencies(self):
+        """Returns the dependency on PointAccuracy."""
+        return self.analysis,
+
+    def describe(self):
+        """Returns descriptions of the results produced by this analysis."""
+        return (
+            Measure("Average point accuracy", "d_avg", minimal=0, maximal=1, direction=Sorting.DESCENDING),
+            Measure("Point accuracy at 1px", "d_1", minimal=0, maximal=1, direction=Sorting.DESCENDING),
+            Measure("Point accuracy at 2px", "d_2", minimal=0, maximal=1, direction=Sorting.DESCENDING),
+            Measure("Point accuracy at 4px", "d_4", minimal=0, maximal=1, direction=Sorting.DESCENDING),
+            Measure("Point accuracy at 8px", "d_8", minimal=0, maximal=1, direction=Sorting.DESCENDING),
+            Measure("Point accuracy at 16px", "d_16", minimal=0, maximal=1, direction=Sorting.DESCENDING),
+            None,
+        )
+
+    def compatible(self, experiment: Experiment):
+        """Only compatible with unsupervised experiments."""
+        return isinstance(experiment, UnsupervisedExperiment)
+
+    def aggregate(self, tracker: Tracker, sequences: List[Sequence], results: Grid) -> Tuple[Any]:
+        """Aggregate per-sequence results into dataset-level scores.
+
+        Args:
+            tracker (Tracker): The tracker.
+            sequences (List[Sequence]): All sequences.
+            results (Grid): Per-sequence results from PointAccuracy.
+
+        Returns:
+            Tuple of (d_avg, d_1, d_2, d_4, d_8, d_16, total_frames).
+        """
+        n_measures = len(THRESHOLDS) + 1
+        weighted_sum = np.zeros(n_measures, dtype=np.float64)
+        n_total = 0
+
+        for result in results:
+            if result is None:
+                continue
+            n = result[-1]
+            if n > 0:
+                for k in range(n_measures):
+                    weighted_sum[k] += result[k] * n
+                n_total += n
+
+        if n_total == 0:
+            return (0.0,) * n_measures + (0,)
+
+        averaged = tuple(float(weighted_sum[k] / n_total) for k in range(n_measures))
+        return averaged + (n_total,)

--- a/vot/region/__init__.py
+++ b/vot/region/__init__.py
@@ -34,6 +34,7 @@ class RegionType(Enum):
     RECTANGLE = 1
     POLYGON = 2
     MASK = 3
+    POINT = 4
 
 class Region(ABC):
     """
@@ -143,4 +144,4 @@ class Special(Region):
         return True
 
 from .raster import calculate_overlap, calculate_overlaps
-from .shapes import Rectangle, Polygon, Mask
+from .shapes import Rectangle, Polygon, Mask, Point

--- a/vot/region/io.py
+++ b/vot/region/io.py
@@ -151,18 +151,23 @@ def parse_region(string: str, separator: str = ",") -> "Region":
     """
     from vot import config
     from vot.region import Special
-    from vot.region.shapes import Rectangle, Polygon, Mask
+    from vot.region.shapes import Rectangle, Polygon, Mask, Point
 
     if string[0] == 'm':
         # input is a mask - decode it
         m_, offset_ = create_mask_from_string(string[1:].split(separator))
         return Mask(m_, offset=offset_, optimize=config.mask_optimize_read)
     else:
-        # input is not a mask - check if special, rectangle or polygon
+        # input is not a mask - check if special, rectangle, polygon or point
         tokens = [float(t) for t in string.split(separator)]
         if len(tokens) == 1:
             return Special(tokens[0])
-        if len(tokens) == 4:
+        elif len(tokens) == 2:
+            if any([math.isnan(el) for el in tokens]):
+                return Special(0)
+            else:
+                return Point(tokens[0], tokens[1])
+        elif len(tokens) == 4:
             if any([math.isnan(el) for el in tokens]):
                 return Special(0)
             else:
@@ -186,7 +191,7 @@ def read_trajectory_binary(fp: io.RawIOBase):
     import struct
     from cachetools import LRUCache, cached
     from vot.region import Special
-    from vot.region.shapes import Rectangle, Polygon, Mask
+    from vot.region.shapes import Rectangle, Polygon, Mask, Point
 
     buffer = dict(data=fp.read(), offset = 0)
 
@@ -217,6 +222,7 @@ def read_trajectory_binary(fp: io.RawIOBase):
             tl_x, tl_y, region_w, region_h, n = read("<hhHHH")
             rle = np.array(read("<%dH" % (n)), dtype=np.int32)
             r = Mask(rle_to_mask(rle, region_w, region_h), (tl_x, tl_y))
+        elif type == 4: r = Point(*read("<ff"))
         else:
             raise IOError("Wrong region type")
         trajectory.append(r)
@@ -231,7 +237,7 @@ def write_trajectory_binary(fp: io.RawIOBase, data: List["Region"]):
     """
     import struct
     from vot.region import Special
-    from vot.region.shapes import Rectangle, Polygon, Mask
+    from vot.region.shapes import Rectangle, Polygon, Mask, Point
 
     fp.write(struct.pack("<hI", 1, len(data)))
 
@@ -239,9 +245,10 @@ def write_trajectory_binary(fp: io.RawIOBase, data: List["Region"]):
         if isinstance(r, Special): fp.write(struct.pack("<BI", 0, r.code))
         elif isinstance(r, Rectangle): fp.write(struct.pack("<Bffff", 1, r.x, r.y, r.width, r.height))
         elif isinstance(r, Polygon): fp.write(struct.pack("<BH%df" % (2 * r.size), 2, r.size, *[item for sublist in r.points() for item in sublist]))
-        elif isinstance(r, Mask): 
+        elif isinstance(r, Mask):
             rle = mask_to_rle(r.mask, maxstride=255*255)
             fp.write(struct.pack("<BhhHHH%dH" % len(rle), 3, r.offset[0], r.offset[1], r.mask.shape[1], r.mask.shape[0], len(rle), *rle))
+        elif isinstance(r, Point): fp.write(struct.pack("<Bff", 4, r.x, r.y))
         else:
             raise IOError("Wrong region type")
 

--- a/vot/region/shapes.py
+++ b/vot/region/shapes.py
@@ -505,3 +505,121 @@ class Mask(Shape):
         """
         bounds = mask_bounds(self.mask)
         return bounds[0] + self.offset[0], bounds[1] + self.offset[1], bounds[2] + self.offset[0], bounds[3] + self.offset[1]
+
+class Point(Shape):
+    """
+    Point region defined by a single (x, y) coordinate.
+    """
+
+    def __init__(self, x=0, y=0):
+        """ Constructor
+
+        Args:
+            x (float): X coordinate of the point.
+            y (float): Y coordinate of the point.
+        """
+        super().__init__()
+        self._data = np.array([[x], [y]], dtype=np.float32)
+
+    def __str__(self):
+        """ Create string from class """
+        return '{},{}'.format(self.x, self.y)
+
+    @property
+    def x(self):
+        """ X coordinate of the point. """
+        return float(self._data[0, 0])
+
+    @property
+    def y(self):
+        """ Y coordinate of the point. """
+        return float(self._data[1, 0])
+
+    @property
+    def type(self):
+        """ Type of the region. """
+        return RegionType.POINT
+
+    def copy(self):
+        """ Create a copy of the point. """
+        return copy(self)
+
+    def convert(self, rtype: RegionType):
+        """ Convert the point to another region type.
+
+        Args:
+            rtype (RegionType): Target region type.
+
+        Returns:
+            Region: Converted region.
+
+        Raises:
+            ConversionException: If the conversion is not supported.
+        """
+        if rtype == RegionType.POINT:
+            return self.copy()
+        else:
+            raise ConversionException("Unable to convert point region to {}".format(rtype), source=self)
+
+    def is_empty(self):
+        """ Check if the point is empty.
+
+        Returns:
+            bool: Always False; a point always has a defined location.
+        """
+        return False
+
+    def draw(self, handle: DrawHandle):
+        """ Draw the point to the given handle.
+
+        Args:
+            handle (DrawHandle): Handle to draw to.
+        """
+        handle.points([(self.x, self.y)])
+
+    def resize(self, factor=1):
+        """ Resize the point by the given factor.
+
+        Args:
+            factor (float): Resize factor.
+
+        Returns:
+            Point: Resized point.
+        """
+        return Point(self.x * factor, self.y * factor)
+
+    def move(self, dx=0, dy=0):
+        """ Move the point by the given offset.
+
+        Args:
+            dx (float): X offset.
+            dy (float): Y offset.
+
+        Returns:
+            Point: Moved point.
+        """
+        return Point(self.x + dx, self.y + dy)
+
+    def rasterize(self, bounds: Tuple[int, int, int, int]):
+        """ Rasterize the point into a binary mask.
+
+        Args:
+            bounds (tuple): Bounding box of the mask as (left, top, right, bottom).
+
+        Returns:
+            numpy.ndarray: Binary mask with a single pixel set at the point location.
+        """
+        mask = np.zeros((bounds[3] - bounds[1] + 1, bounds[2] - bounds[0] + 1), dtype=np.uint8)
+        px = int(round(self.x)) - bounds[0]
+        py = int(round(self.y)) - bounds[1]
+        if 0 <= px < mask.shape[1] and 0 <= py < mask.shape[0]:
+            mask[py, px] = 1
+        return mask
+
+    def bounds(self):
+        """ Get the bounding box of the point.
+
+        Returns:
+            tuple: Bounding box as (left, top, right, bottom). For a point this is a degenerate box.
+        """
+        return int(round(self.x)), int(round(self.y)), int(round(self.x)), int(round(self.y))

--- a/vot/stack/vots2026/votsp.yaml
+++ b/vot/stack/vots2026/votsp.yaml
@@ -1,0 +1,9 @@
+title: VOTS2026 Point Tracking Stack
+dataset: https://data.votchallenge.net/vots2026/point/description.json
+experiments:
+  baseline:
+    type: unsupervised
+    repetitions: 1
+    multiobject: True
+    analyses:
+      - type: vot.analysis.point.AveragePointAccuracy


### PR DESCRIPTION
## Summary

- Adds `RegionType.POINT` and a `Point` shape class (x,y float32 coordinate), following the existing Rectangle/Polygon/Mask style
- Updates `parse_region` to handle 2-token lines as `Point(x, y)`
- Updates binary trajectory I/O for Point (type byte `4`, `<Bff` format)
- Adds `vot/analysis/point.py` with `PointAccuracy` and `AveragePointAccuracy` implementing the `d_avg` metric: average fraction of correctly-tracked points across thresholds [1, 2, 4, 8, 16] px, computed in a resolution-normalized 256×256 space so thresholds are comparable across videos of different resolutions
- Adds `vot/stack/vots2026/votsp.yaml` pointing to the VOTSp2026 dataset

## Notes

- Point tracking uses `UnsupervisedExperiment` with `multiobject: True`, consistent with VOTS2023+ stacks
- Ground truth format is `groundtruth_pt{N}.txt` (one `x,y` per line) which is already handled by the existing multi-object glob in `dataset/common.py`
- Tracker integration via trax is currently blocked pending a `Point` region type being added to `votchallenge/trax`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)