### PR TITLE
Referral: fix empty-mask IoU semantics; drop unused success-plot analyses

### DIFF
--- a/data/aliases/analysis.json
+++ b/data/aliases/analysis.json
@@ -30,7 +30,5 @@
     "point_accuracy": "vot.analysis.point.PointAccuracy",
     "point_average_accuracy": "vot.analysis.point.AveragePointAccuracy",
     "referral_accuracy": "vot.analysis.referral.ReferralSequenceAccuracy",
-    "referral_average_accuracy": "vot.analysis.referral.ReferralAverageAccuracy",
-    "referral_success_plot": "vot.analysis.referral.ReferralSuccessPlot",
-    "referral_average_success_plot": "vot.analysis.referral.ReferralAverageSuccessPlot"
+    "referral_average_accuracy": "vot.analysis.referral.ReferralAverageAccuracy"
 }

--- a/vot/analysis/referral.py
+++ b/vot/analysis/referral.py
@@ -2,39 +2,93 @@
 
 Computes mean IoU between each prompt's predicted masks and the single GT
 object, averaged across prompts and then across sequences.
+
+Per-frame IoU semantics (matches the participant's evaluation pipeline):
+  - "0" line in groundtruth_object1.txt -> frame has no annotation (6fps gap):
+    SKIP (does not contribute to the average).
+  - "m..." line whose mask is empty -> frame is annotated and the GT mask is
+    empty (e.g. the referenced object disappeared): COUNT.
+        * if prediction is also empty -> IoU = 1
+        * if prediction is non-empty  -> IoU = 0
+  - "m..." line whose mask is non-empty -> standard IoU vs prediction
+    (with ignore mask applied if present).
 """
 
 from typing import List, Tuple, Any
 
 import numpy as np
 
-from attributee import Boolean, Integer, Float, Include, String
+from attributee import Boolean, Include, String
 
 from vot.analysis import (Measure, MissingResultsException, SequenceAggregator,
-                          Sorting, SeparableAnalysis, Curve, is_special)
+                          Sorting, SeparableAnalysis, is_special)
 from vot.dataset import Sequence
 from vot.experiment import Experiment
 from vot.experiment.referral import ReferralExperiment
-from vot.region import Region, calculate_overlaps
-from vot.tracker import Tracker, Trajectory
+from vot.region.shapes import Mask
+from vot.tracker import Tracker
 from vot.utilities.data import Grid
-from vot.analysis.accuracy import gather_overlaps
+
+
+def _render_mask(region, height: int, width: int):
+    """Render a Region into a (H, W) bool numpy array. Returns None if the
+    region cannot be interpreted as a mask (unknown / non-mask shape).
+    """
+    if region is None:
+        return None
+    if not isinstance(region, Mask):
+        return None
+    m = region.mask
+    if m.size == 0:
+        return np.zeros((height, width), dtype=bool)
+    ox, oy = region.offset
+    out = np.zeros((height, width), dtype=bool)
+    h0, w0 = m.shape
+    x0, y0 = max(ox, 0), max(oy, 0)
+    x1, y1 = min(ox + w0, width), min(oy + h0, height)
+    if x1 > x0 and y1 > y0:
+        out[y0:y1, x0:x1] = m[y0 - oy:y1 - oy, x0 - ox:x1 - ox].astype(bool)
+    return out
+
+
+def _per_frame_iou(gt_mask, pred_mask, ignore_mask=None) -> float:
+    """IoU between two (H, W) bool arrays, applying ignore mask.
+
+    Empty-mask convention:
+      both empty -> 1.0
+      gt empty, pred non-empty -> 0.0
+      gt non-empty, pred empty -> 0.0
+      otherwise -> standard IoU (intersection / union).
+    """
+    if ignore_mask is not None:
+        gt_mask = gt_mask & ~ignore_mask
+        pred_mask = pred_mask & ~ignore_mask
+
+    gt_any = bool(gt_mask.any())
+    pr_any = bool(pred_mask.any())
+
+    if not gt_any and not pr_any:
+        return 1.0
+    if not gt_any or not pr_any:
+        return 0.0
+    inter = np.logical_and(gt_mask, pred_mask).sum()
+    union = np.logical_or(gt_mask, pred_mask).sum()
+    return float(inter) / float(union) if union > 0 else 1.0
 
 
 class ReferralSequenceAccuracy(SeparableAnalysis):
     """Per-sequence accuracy for referral experiments.
 
-    For each prompt, computes the mean IoU of the predicted trajectory against
-    the single GT object (filtered by evaluation tag, with ignore masks).
-    The sequence-level score is the mean across all prompts.
+    Collects IoU values for every (prompt, frame) pair that has an annotation
+    (skipping the 6fps gaps where groundtruth_object1.txt has "0"). For
+    annotated frames whose GT mask is empty (e.g. the object disappeared)
+    the IoU is 1 if the prediction is also empty, else 0.
     """
 
-    burnin = Integer(default=0, val_min=0)
-    ignore_unknown = Boolean(default=False, description="If False, missing predictions count as 0 IoU.")
-    ignore_invisible = Boolean(default=False)
-    bounded = Boolean(default=True)
-    ignore_masks = String(default="_ignore")
-    filter_tag = String(default=None)
+    ignore_masks = String(default="_ignore",
+        description="Object id whose regions are treated as ignore masks.")
+    filter_tag = String(default=None,
+        description="Only count frames carrying this tag.")
 
     def compatible(self, experiment: Experiment):
         return isinstance(experiment, ReferralExperiment)
@@ -54,13 +108,12 @@ class ReferralSequenceAccuracy(SeparableAnalysis):
         if len(trajectories) == 0:
             raise MissingResultsException()
 
-        bounds = sequence.size if self.bounded else None
-
         objects = [o for o in sequence.objects() if not o.startswith("_")]
         assert len(objects) == 1, f"Referral expects single-object sequences, got {objects}"
         groundtruth = sequence.object(objects[0])
-
         ignore_regions = sequence.object(self.ignore_masks)
+
+        W, H = sequence.size
 
         if self.filter_tag is not None:
             frame_mask = [self.filter_tag in sequence.tags(i)
@@ -70,41 +123,52 @@ class ReferralSequenceAccuracy(SeparableAnalysis):
         else:
             frame_mask = None
 
-        prompt_accuracies = []
+        # Pre-render GT and ignore masks once (shared across prompts).
+        gt_arrays: List = []
+        annotated: List[bool] = []
+        for i, gt in enumerate(groundtruth):
+            if is_special(gt, Sequence.UNKNOWN):
+                gt_arrays.append(None); annotated.append(False); continue
+            if frame_mask is not None and not frame_mask[i]:
+                gt_arrays.append(None); annotated.append(False); continue
+            gt_arrays.append(_render_mask(gt, H, W))
+            annotated.append(gt_arrays[-1] is not None)
+
+        ig_arrays = [None] * len(groundtruth)
+        if ignore_regions is not None:
+            for i, ig in enumerate(ignore_regions):
+                if isinstance(ig, Mask):
+                    ig_arrays[i] = _render_mask(ig, H, W)
+
+        all_overlaps: List[float] = []
 
         for trajectory in trajectories:
-            if frame_mask is not None:
-                traj_f = [r for r, m in zip(trajectory, frame_mask) if m]
-                gt_f = [r for r, m in zip(groundtruth, frame_mask) if m]
-                masks_f = ([r for r, m in zip(ignore_regions, frame_mask) if m]
-                           if ignore_regions else None)
-            else:
-                traj_f = list(trajectory)
-                gt_f = groundtruth
-                masks_f = ignore_regions
+            pred_regions = trajectory.regions()
+            for i in range(len(groundtruth)):
+                if not annotated[i]:
+                    continue
+                gm = gt_arrays[i]
+                pred_region = pred_regions[i] if i < len(pred_regions) else None
+                pm = _render_mask(pred_region, H, W)
+                if pm is None:
+                    pm = np.zeros((H, W), dtype=bool)
+                all_overlaps.append(_per_frame_iou(gm, pm, ig_arrays[i]))
 
-            overlaps, _ = gather_overlaps(
-                traj_f, gt_f,
-                burnin=self.burnin,
-                ignore_unknown=self.ignore_unknown,
-                ignore_invisible=self.ignore_invisible,
-                bounds=bounds,
-                ignore_masks=masks_f,
-            )
-
-            if overlaps.size > 0:
-                prompt_accuracies.append(float(np.mean(overlaps)))
-            else:
-                prompt_accuracies.append(0.0)
-
-        return float(np.mean(prompt_accuracies)),
+        return (float(np.mean(all_overlaps)) if all_overlaps else 0.0),
 
 
 class ReferralAverageAccuracy(SequenceAggregator):
-    """Average referral accuracy across sequences."""
+    """Average referral accuracy across sequences.
+
+    Reports the mean IoU over every evaluated (sequence, prompt, frame) triple,
+    weighted by the number of evaluated frames per sequence (i.e. true mean
+    IoU per predicted frame). Frames without GT (6fps gaps, empty GT masks)
+    are excluded by ReferralSequenceAccuracy.
+    """
 
     analysis = Include(ReferralSequenceAccuracy)
-    weighted = Boolean(default=True, description="Weight accuracy by sequence length.")
+    weighted = Boolean(default=True,
+        description="Weight by sequence length (proportional to number of evaluated frames).")
 
     def compatible(self, experiment: Experiment):
         return isinstance(experiment, ReferralExperiment)
@@ -121,139 +185,21 @@ class ReferralAverageAccuracy(SequenceAggregator):
 
     def aggregate(self, _: Tracker, sequences: List[Sequence],
                   results: Grid):
-        accuracy = 0
-        frames = 0
+        accuracy = 0.0
+        weight = 0.0
 
         for i, sequence in enumerate(sequences):
             if results[i, 0] is None:
                 continue
+            seq_iou = results[i, 0][0]
 
             if self.weighted:
-                accuracy += results[i, 0][0] * len(sequence)
-                frames += len(sequence)
+                accuracy += seq_iou * len(sequence)
+                weight += len(sequence)
             else:
-                accuracy += results[i, 0][0]
-                frames += 1
+                accuracy += seq_iou
+                weight += 1
 
-        return (accuracy / frames,) if frames > 0 else (0.0,)
-
-
-class ReferralSuccessPlot(SeparableAnalysis):
-    """Success plot for referral experiments — IoU threshold sweep."""
-
-    ignore_unknown = Boolean(default=False)
-    ignore_invisible = Boolean(default=False)
-    burnin = Integer(default=0, val_min=0)
-    bounded = Boolean(default=True)
-    resolution = Integer(default=100, val_min=2)
-    ignore_masks = String(default="_ignore")
-    filter_tag = String(default=None)
-
-    def compatible(self, experiment: Experiment):
-        return isinstance(experiment, ReferralExperiment)
-
-    @property
-    def _title_default(self):
-        return "Referral success plot"
-
-    def describe(self):
-        return Curve("Plot", 2, "S", minimal=(0, 0), maximal=(1, 1),
-                     labels=("Threshold", "Success"), trait="success"),
-
-    def subcompute(self, experiment: Experiment, tracker: Tracker,
-                   sequence: Sequence, dependencies: List[Grid]) -> Tuple[Any]:
-        assert isinstance(experiment, ReferralExperiment)
-
-        trajectories = experiment.gather(tracker, sequence)
-        if len(trajectories) == 0:
-            raise MissingResultsException()
-
-        bounds = sequence.size if self.bounded else None
-
-        objects = [o for o in sequence.objects() if not o.startswith("_")]
-        assert len(objects) == 1
-        groundtruth = sequence.object(objects[0])
-        ignore_regions = sequence.object(self.ignore_masks)
-
-        if self.filter_tag is not None:
-            frame_mask = [self.filter_tag in sequence.tags(i)
-                          for i in range(len(sequence))]
-            if not any(frame_mask):
-                frame_mask = None
-        else:
-            frame_mask = None
-
-        axis_x = np.linspace(0, 1, self.resolution)
-        axis_y = np.zeros_like(axis_x)
-        valid_prompts = 0
-
-        for trajectory in trajectories:
-            if frame_mask is not None:
-                traj_f = [r for r, m in zip(trajectory, frame_mask) if m]
-                gt_f = [r for r, m in zip(groundtruth, frame_mask) if m]
-                masks_f = ([r for r, m in zip(ignore_regions, frame_mask) if m]
-                           if ignore_regions else None)
-            else:
-                traj_f = list(trajectory)
-                gt_f = groundtruth
-                masks_f = ignore_regions
-
-            overlaps, _ = gather_overlaps(
-                traj_f, gt_f,
-                burnin=self.burnin,
-                ignore_unknown=self.ignore_unknown,
-                ignore_invisible=self.ignore_invisible,
-                bounds=bounds,
-                ignore_masks=masks_f,
-            )
-
-            if len(overlaps) == 0:
-                continue
-
-            valid_prompts += 1
-            for i, threshold in enumerate(axis_x):
-                if threshold == 1:
-                    axis_y[i] += np.sum(overlaps >= threshold) / len(overlaps)
-                else:
-                    axis_y[i] += np.sum(overlaps > threshold) / len(overlaps)
-
-        if valid_prompts > 0:
-            axis_y /= valid_prompts
-
-        return [(x, y) for x, y in zip(axis_x, axis_y)],
+        return (accuracy / weight,) if weight > 0 else (0.0,)
 
 
-class ReferralAverageSuccessPlot(SequenceAggregator):
-    """Average success plot across sequences for referral experiments."""
-
-    resolution = Integer(default=100, val_min=2)
-    analysis = Include(ReferralSuccessPlot)
-
-    def dependencies(self):
-        return self.analysis,
-
-    def compatible(self, experiment: Experiment):
-        return isinstance(experiment, ReferralExperiment)
-
-    @property
-    def _title_default(self):
-        return "Referral success plot"
-
-    def describe(self):
-        return Curve("Plot", 2, "S", minimal=(0, 0), maximal=(1, 1),
-                     labels=("Threshold", "Success"), trait="success"),
-
-    def aggregate(self, _: Tracker, sequences: List[Sequence],
-                  results: Grid):
-        axis_x = np.linspace(0, 1, self.resolution)
-        axis_y = np.zeros_like(axis_x)
-
-        for i, _ in enumerate(sequences):
-            if results[i, 0] is None:
-                continue
-            curve = results[i, 0][0]
-            for j, (_, y) in enumerate(curve):
-                axis_y[j] += y
-
-        axis_y /= len(sequences)
-        return [(x, y) for x, y in zip(axis_x, axis_y)],

--- a/vot/stack/vots2026/referralval.yaml
+++ b/vot/stack/vots2026/referralval.yaml
@@ -6,9 +6,4 @@ experiments:
     analyses:
       - type: referral_average_accuracy
         name: Quality
-        bounded: true
-        ignore_unknown: false
-        weighted: false
-      - type: referral_average_success_plot
-        name: Quality plot
-        ignore_unknown: false
+        weighted: true


### PR DESCRIPTION
While testing the referral analysis end-to-end against ground-truth predictions
on the VOTSr2026 test set, two issues surfaced:
1. `ReferralSequenceAccuracy` (via the old `gather_overlaps`) skipped every
   frame whose GT mask was empty, regardless of whether the frame was
   un-annotated (6fps gaps) or genuinely "object absent". This made
   "object disappeared" cases (e.g. an extinguished flame) silently disappear
   from the average.
2. The `ReferralSuccessPlot` / `ReferralAverageSuccessPlot` analyses
   weren't actually used in the validation stack and added complexity.
Changes:
- `ReferralSequenceAccuracy`: skip only `Special(0)` (truly un-annotated
  frames, the 6fps gaps). For annotated frames the IoU is computed manually
  with the convention `both empty → 1`, `one empty → 0`, otherwise standard
  IoU (with ignore mask AND-ed out).
- `ReferralAverageAccuracy` is unchanged conceptually; it weights each
  sequence's mean IoU by its length to give a true per-frame mean.
- Dropped `ReferralSuccessPlot` / `ReferralAverageSuccessPlot` and their
  aliases in `data/aliases/analysis.json`.
- `vots2026/referralval.yaml`: removed now-unused
  `bounded` / `ignore_unknown` / `ignore_invisible` parameters.